### PR TITLE
Theta23 octant check bugfix

### DIFF
--- a/pisa/analysis/llr/LLHAnalysis.py
+++ b/pisa/analysis/llr/LLHAnalysis.py
@@ -10,6 +10,7 @@
 #
 
 import sys
+from copy import deepcopy
 import numpy as np
 import scipy.optimize as opt
 
@@ -134,20 +135,21 @@ def find_opt_bfgs(fmap, template_maker, params, bfgs_settings,
 
     # If needed, run optimizer again, checking for second octant solution:
     if check_octant and ('theta23' in free_params.keys()):
+        free_params_copy = deepcopy(free_params)
         physics.info("Checking alternative octant solution")
-        old_th23_val = free_params['theta23']['value']
+        old_th23_val = free_params_copy['theta23']['value']
 
         # Reflect across pi/4.0:
         delta = (np.pi/4.0) - old_th23_val
-        free_params['theta23']['value'] = (np.pi/4.0) + delta
+        free_params_copy['theta23']['value'] = (np.pi/4.0) + delta
 
-        init_vals = get_param_values(free_params)
+        init_vals = get_param_values(free_params_copy)
 
         alt_opt_steps_dict = {key:[] for key in names}
         alt_opt_steps_dict[metric_name] = []
         const_args = (names, scales, fmap, fixed_params, template_maker,
                       alt_opt_steps_dict, priors, metric_name)
-        display_optimizer_settings(free_params=free_params,
+        display_optimizer_settings(free_params=free_params_copy,
                                    names=names,
                                    init_vals=init_vals,
                                    bounds=bounds,
@@ -159,7 +161,7 @@ def find_opt_bfgs(fmap, template_maker, params, bfgs_settings,
 
 
         # Alternative octant solution is optimal:
-        if alt_llh < llh:
+        if alt_metric_val < metric_val:
             best_fit_vals = alt_fit_vals
             metric_val = alt_metric_val
             dict_flags = alt_dict_flags

--- a/pisa/utils/params.py
+++ b/pisa/utils/params.py
@@ -82,6 +82,7 @@ class Prior(object):
     def __init_uniform(self):
         self.kind = 'uniform'
         self.llh = lambda x: 0.*x
+        self.chi2 = lambda x: 0.*x
         self.valid_range = [-np.inf, np.inf]
         self.max_at = np.nan
         self.max_at_str = "no maximum"


### PR DESCRIPTION
…udo-experiments are generated: mirroring theta23 changed its true value, because the original params dict got modified. Now a deep copy is made instead. Two smaller fixes: uniform prior for use with chisquare; undefined variable that somehow had been reverted to its old state before PR#27.