### PR TITLE
No cuts by default (and working) for make_events_file.py (and dataProcParams.py)

### DIFF
--- a/pisa/i3utils/make_events_file.py
+++ b/pisa/i3utils/make_events_file.py
@@ -475,7 +475,6 @@ def main():
         '--cut',
         metavar='CUT_NAME',
         type=str,
-        default='analysis',
         help='''Name of pre-defined cut to apply. See
         resources/events/data_proc_params.json for definitions for the detector
         and processing version you're working with (note that the names of cuts

--- a/pisa/utils/dataProcParams.py
+++ b/pisa/utils/dataProcParams.py
@@ -387,6 +387,14 @@ class DataProcParams(dict):
         if isinstance(cuts, basestring) or isinstance(cuts, dict):
             cuts = [cuts]
 
+        # Default is to return all fields
+        if return_fields is None:
+            return_fields = self['field_map'].keys()
+
+        # If no cuts specified, return all data from specified fields
+        if len(cuts) == 0:
+            return {f:np.array(data[f]) for f in return_fields}
+
         cut_strings = set()
         cut_fields = set()
         for cut in cuts:
@@ -408,10 +416,6 @@ class DataProcParams(dict):
 
         # Evaluate cuts, returning a boolean array
         bool_idx = eval(cut_string)
-
-        # Default is to return all fields
-        if return_fields is None:
-            return_fields = self['field_map'].keys()
 
         # Return specified (or all) fields, indexed by boolean array
         return {f:np.array(data[f])[bool_idx] for f in return_fields}


### PR DESCRIPTION
make_events_file.py now defaults to no cuts (was defaulting to "analysis" cut (however that is defined for the corresponding detector/processing version in data_proc_params.json). Now one must specify explicitly a cut via --cut or --ccut if one wants a cut (or multiple cuts) to be applied. Also implemented a small bugfix in dataProcParams.py to allow for no cuts to be specified and not break in the applyCuts() method.

Command line call of make_events_file.py w/o any cut:
```bash
make_events_file.py --det "pingu" --proc "5" --nue ... --numu ... ...
```
Command line call of same with what was previously the default:
```bash
$PISA/pisa/i3utils/make_events_file.py --det "pingu" --proc "5" --cut "analysis" --nue ... --numu ... ...
```