### PR TITLE
Conserving channel-wise information and consistent treatment of channels

### DIFF
--- a/pisa/analysis/asimov/AsimovOptimizerAnalysis.py
+++ b/pisa/analysis/asimov/AsimovOptimizerAnalysis.py
@@ -20,7 +20,6 @@ from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from pisa.utils.log import logging, tprofile, physics, set_verbosity
 from pisa.utils.jsons import from_json,to_json
 from pisa.analysis.llr.LLHAnalysis import find_opt_scipy
-from pisa.analysis.stats.Maps import get_channel_template
 from pisa.analysis.TemplateMaker import TemplateMaker
 from pisa.utils.params import get_values, select_hierarchy
 

--- a/pisa/analysis/llr/LLHAnalysis.py
+++ b/pisa/analysis/llr/LLHAnalysis.py
@@ -48,7 +48,7 @@ def find_alt_hierarchy_fit(asimov_data_set, template_maker,hypo_params,hypo_norm
     hypo_params = select_hierarchy(hypo_params, normal_hierarchy=hypo_normal)
 
     with Timer() as t:
-        llh_data = find_opt_scipy(
+        llh_data, opt_flags = find_opt_scipy(
             fmap=asimov_data_set,
             template_maker=template_maker,
             params=hypo_params,
@@ -57,7 +57,7 @@ def find_alt_hierarchy_fit(asimov_data_set, template_maker,hypo_params,hypo_norm
             check_octant=check_octant)
     tprofile.info("==> elapsed time for optimizer: %s sec"%t.secs)
 
-    return llh_data
+    return llh_data, opt_flags
 
 def display_optimizer_settings(free_params, names, init_vals, bounds, priors,
                                minim_settings):

--- a/pisa/analysis/stats/LLHStatistics.py
+++ b/pisa/analysis/stats/LLHStatistics.py
@@ -16,6 +16,8 @@ from scipy.special import multigammaln
 from scipy.stats import poisson
 
 from pisa.utils.jsons import from_json
+from pisa.utils.utils import get_all_channel_names
+from pisa.analysis.stats.Maps import get_channel_template
 
 
 def generalized_ln_poisson(data, expectation):
@@ -43,38 +45,60 @@ def generalized_ln_poisson(data, expectation):
         raise ValueError(
             "Unknown data dtype: %s. Must be float or int!"%psuedo_data.dtype)
 
-def get_binwise_llh(pseudo_data, template):
+def get_binwise_llh(pseudo_data, template, channel='all'):
     """
     Computes the log-likelihood (llh) of the pseudo_data from the
     template, where each input is expected to be a 2d numpy array
     """
-    if not np.alltrue(template >= 0.0):
-        raise ValueError("Template must have all bins >= 0.0! Template generation bug?")
-
-    totalLLH = np.sum(generalized_ln_poisson(pseudo_data,template))
+    if isinstance(pseudo_data, dict) and isinstance(template, dict):
+	pd_channel_tmpl = get_channel_template(pseudo_data, channel)
+	hypo_tmpl = get_channel_template(template, channel)
+	totalLLH = {}
+	pd_chans = \
+	    sorted(list(set(pd_channel_tmpl.keys()) & set(get_all_channel_names())))
+	tmpl_chans = \
+	    sorted(list(set(hypo_tmpl.keys()) & set(get_all_channel_names())))
+	if not pd_chans==tmpl_chans:
+            raise ValueError("Templates must have the same channels.")
+	for chan in pd_chans:
+	    if not np.alltrue(hypo_tmpl[chan] >= 0.0):
+	        raise ValueError("""Template must have all bins >= 0.0! """
+				 """Template generation bug?""")
+	    totalLLH[chan] = \
+	        np.sum(generalized_ln_poisson(
+                    pd_channel_tmpl[chan],hypo_tmpl[chan]))
+    else:
+	raise TypeError("Incompatible type(s): pseudo data=%s, template=%s" %
+			(type(pseudo_data), type(template)))
 
     return totalLLH
 
-def get_binwise_chisquare(pseudo_data, template):
-    '''
+def get_binwise_chisquare(pseudo_data, template, channel='all'):
+    """
     Computes the chisquare between the pseudo_data
     and the template, where each input is expected to be a 2d numpy array
-    '''
-    if not np.alltrue(template >= 0.0):
-        raise ValueError("Template must have all bins >= 0.0! Template generation bug?")
-
-    total_chisquare = np.sum(np.divide(np.power((pseudo_data - template), 2), pseudo_data))
+    """
+    if isinstance(pseudo_data, dict) and isinstance(template, dict):
+	pd_channel_tmpl = get_channel_template(pseudo_data, channel)
+	hypo_tmpl = get_channel_template(template, channel)
+	total_chisquare = {}
+	pd_chans = \
+	    sorted(list(set(pd_channel_tmpl.keys()) & set(get_all_channel_names())))
+	tmpl_chans = \
+	    sorted(list(set(hypo_tmpl.keys()) & set(get_all_channel_names())))
+	if not pd_chans==tmpl_chans:
+            raise ValueError("Templates must have the same channels.")
+	for chan in pd_chans:
+	    if not np.alltrue(hypo_tmpl[chan] >= 0.0):
+	        raise ValueError("""Template must have all bins >= 0.0! """
+				 """Template generation bug?""")
+	    total_chisquare[chan] = \
+	        np.sum(np.divide(np.power(
+		      (pd_channel_tmpl[chan] - hypo_tmpl[chan]), 2),
+		       pd_channel_tmpl[chan]))
+    else:
+	raise TypeError("Incompatible type(s): pseudo data=%s, template=%s" %
+			(type(pseudo_data), type(template)))
 
     return total_chisquare
 
-def get_random_map(template, seed=None):
-    """
-    Gets an event map with integer entries from non-integer entries
-    (in general) in the template, varied according to Poisson
-    statistics.
-    """
-    # Set the seed if given
-    if not seed is None:
-        np.random.seed(seed=seed)
-
-    return poisson.rvs(template)

--- a/pisa/analysis/stats/Maps.py
+++ b/pisa/analysis/stats/Maps.py
@@ -8,9 +8,10 @@
 
 import os
 import numpy as np
-from pisa.analysis.stats.LLHStatistics import get_random_map
-from pisa.utils.log import logging
+from scipy.stats import poisson
 
+from pisa.utils.log import logging
+from pisa.utils.utils import get_all_channel_names, get_channels
 
 def apply_ratio_scale(orig_maps, key1, key2, ratio_scale, is_flux_scale, int_type=None):
     """
@@ -63,47 +64,24 @@ def get_pseudo_data_fmap(template_maker, fiducial_params, channel, seed=None):
     fmap = get_random_map(true_fmap, seed=seed)
     return fmap
 
-def get_asimov_fmap(template_maker, fiducial_params, channel=None):
-    """Creates a true template from fiducial_params"""
-
-    true_template = template_maker.get_template(fiducial_params)
-    #print "  params in asimov: ",fiducial_params.items()
-    return flatten_map(true_template, channel=channel)
-
-def flatten_map(template, channel='all'):
+def get_channel_template(template, channel='all'):
     """
-    Takes a final level true (expected) template of trck/cscd, and returns a
-    single flattened map of trck appended to cscd, with all zero bins
-    removed.
+    Takes a final level true (expected) template, and returns template for
+    the selected channel, with zero bins removed.
     """
-
-    logging.trace("Getting flattened map of channel: %s"%channel)
-
-    if channel == 'all':
-        cscd = template['cscd']['map'].flatten()
-        trck = template['trck']['map'].flatten()
-        fmap = np.append(cscd, trck)
-    elif channel == 'trck':
-        trck = template[channel]['map'].flatten()
-        fmap = np.array(trck)
-        #fmap = np.array(fmap)[np.nonzero(fmap)]
-    elif channel == 'cscd':
-        cscd = template[channel]['map'].flatten()
-        fmap = np.array(cscd)
-        #fmap = np.array(fmap)[np.nonzero(fmap)]
-    elif channel == 'no_pid':
-        cscd = template['cscd']['map'].flatten()
-        trck = template['trck']['map'].flatten()
-        fmap = cscd + trck
-        #fmap = np.array(fmap)[np.nonzero(fmap)]
+    channels = get_channels(channel)
+    logging.trace("Creating map of channel: %s"%channel)
+    channel_template = {}
+    if channels == ['no_pid']:
+        channel_template['no_pid'] = \
+		np.sum([ template[chan]['map'].flatten()
+                          for chan in get_channels('all') ], axis=0)
     else:
-        raise ValueError(
-            "channel: '%s' not implemented! Allowed: ['all', 'trck', 'cscd', 'no_pid']"
-            %channel)
+        for chan in channels:
+            channel_template[chan] = template[chan]['map'].flatten()
 
+    return channel_template
 
-    fmap = np.array(fmap)[np.nonzero(fmap)]
-    return fmap
 
 def get_seed():
     """
@@ -112,3 +90,15 @@ def get_seed():
     """
 
     return int(os.urandom(4).encode('hex'), 16)
+
+def get_random_map(template, seed=None):
+    """
+    Gets an event map with integer entries from non-integer entries
+    (in general) in the template, varied according to Poisson
+    statistics.
+    """
+    # Set the seed if given
+    if not seed is None:
+        np.random.seed(seed=seed)
+
+    return poisson.rvs(template)

--- a/pisa/analysis/stats/Maps.py
+++ b/pisa/analysis/stats/Maps.py
@@ -99,6 +99,7 @@ def get_random_map(template, seed=None):
     """
     # Set the seed if given
     if not seed is None:
-        np.random.seed(seed=seed)
+	np.random.seed(seed=seed)
 
-    return poisson.rvs(template)
+    return { chan: {'map': poisson.rvs(tmplt['map'])}
+	for (chan, tmplt) in template.items() if chan in get_all_channel_names() }

--- a/pisa/utils/utils.py
+++ b/pisa/utils/utils.py
@@ -778,5 +778,25 @@ def hash_file(fname):
     return md5.hexdigest()
 
 
+def get_all_channel_names():
+    """Return all allowed channel keywords."""
+    return ['all', 'cscd', 'trck', 'no_pid']
+
+
+def get_channels(channel_name):
+    """Return list of analysis channel(s) for a specific channel name."""
+    if not isinstance(channel_name, basestring):
+        raise TypeError('Wrong type: %s. String required!'%type(channel_name))
+    channel_name = channel_name.lower()
+    allowed_channel_names = get_all_channel_names()
+    if not channel_name in allowed_channel_names:
+        raise ValueError(
+            "channel name: '%s' not implemented! Allowed: %s"
+            %(channel_name, allowed_channel_names))
+    if channel_name == 'all':
+      return ['cscd', 'trck']
+    return [channel_name]
+
+
 if __name__ == "__main__":
     test_recursiveEquality()


### PR DESCRIPTION
Functions calculating llh, chisquare now work directly on templates generated by TemplateMaker and conserve contributions from the different channels (as opposed to user having to convert them beforehand). Also provide getter functions for allowed channels. If people think this is useful, some renaming and other minor changes still need to be made.