### PR TITLE
Functional PID Systematics

### DIFF
--- a/pisa/analysis/TemplateMaker.py
+++ b/pisa/analysis/TemplateMaker.py
@@ -189,7 +189,7 @@ class TemplateMaker:
         logging.info("STAGE 5: Getting pid maps...")
         with Timer(verbose=False) as t:
             final_event_rate = get_pid_maps(event_rate_reco_maps,
-                                            self.pid_service)
+                                            self.pid_service, **params)
         tprofile.debug("==> elapsed time for pid stage: %s sec"%t.secs)
 
         if not return_stages:

--- a/pisa/pid/PID.py
+++ b/pisa/pid/PID.py
@@ -27,16 +27,14 @@ from pisa.pid.PIDServiceParam import PIDServiceParam
 from pisa.pid.PIDServiceKernelFile import PIDServiceKernelFile
 
 
-def get_pid_maps(reco_events, pid_service=None, recalculate=False,
+def get_pid_maps(reco_events, pid_service=None,
                  return_unknown=False, **kwargs):
     """
     Primary function for this service, which returns the classified
     event rate maps (sorted after tracks and cascades) from the
     reconstructed ones (sorted after nu[e,mu,tau]_cc and nuall_nc).
     """
-    if recalculate:
-        pid_service.recalculate_kernels(**kwargs)
-
+    pid_service.recalculate_kernels(**kwargs)
     #Be verbose on input
     params = get_params()
     report_params(params, units = [])

--- a/pisa/pid/PIDServiceBase.py
+++ b/pisa/pid/PIDServiceBase.py
@@ -12,6 +12,7 @@ import logging
 
 import numpy as np
 
+from copy import copy
 from pisa.utils.jsons import to_json
 from pisa.utils.utils import is_equal_binning
 

--- a/pisa/pid/PIDServiceKernelFile.py
+++ b/pisa/pid/PIDServiceKernelFile.py
@@ -32,11 +32,12 @@ class PIDServiceKernelFile(PIDServiceBase):
 
 
     def get_pid_kernels(self, pid_kernelfile=None, **kwargs):
-        logging.info('Opening file: %s'%(pid_kernelfile))
-        try:
-            self.pid_kernels = from_json(find_resource(pid_kernelfile))
-        except IOError, e:
-            logging.error("Unable to open kernel file %s"%pid_kernelfile)
-            logging.error(e)
-            sys.exit(1)
+        if not hasattr(self, 'pid_kernels'):
+            logging.info('Opening file: %s'%(pid_kernelfile))
+            try:
+                self.pid_kernels = from_json(find_resource(pid_kernelfile))
+            except IOError, e:
+                logging.error("Unable to open kernel file %s"%pid_kernelfile)
+                logging.error(e)
+                sys.exit(1)
         return self.pid_kernels

--- a/pisa/pid/PIDServiceParam.py
+++ b/pisa/pid/PIDServiceParam.py
@@ -28,20 +28,20 @@ class PIDServiceParam(PIDServiceBase):
     Systematic parameters 'PID_offset' and 'PID_scale' are supported.
     """
 
-    def __init__(self, ebins, czbins, **kwargs):
+    def __init__(self, ebins, czbins, PID_offset=0., PID_scale=1., pid_paramfile=None, **kwargs):
         """
         Parameters needed to initialize a PID service with parametrizations:
         * ebins: Energy bin edges
         * czbins: cos(zenith) bin edges
         * pid_paramfile: JSON containing the parametrizations
         """
-        PIDServiceBase.__init__(self, ebins, czbins, **kwargs)
+        self.offset = PID_offset
+        self.scale = PID_scale
+        self.paramfile = pid_paramfile
+        PIDServiceBase.__init__(self, ebins, czbins, PID_offset=self.offset, PID_scale=self.scale,
+			        pid_paramfile=self.paramfile, **kwargs)
 
-
-    def get_pid_kernels(self, pid_paramfile=None,
-                        PID_offset=0., PID_scale=1., **kwargs):
-
-        # load parametrization file
+    def kernel_from_paramfile(self, PID_offset=None, PID_scale=None, pid_paramfile=None, **kwargs):
         logging.info('Opening PID parametrization file %s'%pid_paramfile)
         try:
             param_str = from_json(find_resource(pid_paramfile))
@@ -50,12 +50,10 @@ class PIDServiceParam(PIDServiceBase):
                           %pid_paramfile)
             logging.error(e)
             raise
-
         ecen = get_bin_centers(self.ebins)
         czcen = get_bin_centers(self.czbins)
-
-        self.pid_kernels = {'binning': {'ebins': self.ebins,
-                                        'czbins': self.czbins}}
+        pid_kernels = {'binning': {'ebins': self.ebins,
+                                   'czbins': self.czbins}}
         for signature in param_str.keys():
             #Generate the functions
             to_trck_func = eval(param_str[signature]['trck'])
@@ -78,7 +76,28 @@ class PIDServiceParam(PIDServiceBase):
             _,to_trck_map = np.meshgrid(czcen, PID_scale*to_trck)
             _,to_cscd_map = np.meshgrid(czcen, PID_scale*to_cscd)
 
-            self.pid_kernels[signature] = {'trck':to_trck_map,
-                                           'cscd':to_cscd_map}
+            pid_kernels[signature] = {'trck':to_trck_map,
+                                      'cscd':to_cscd_map}
+        # now update
+        self.offset = PID_offset
+        self.scale = PID_scale
+        self.paramfile = pid_paramfile
+        return pid_kernels
 
-        return self.pid_kernels
+    def get_pid_kernels(self, PID_offset=None, PID_scale=None, pid_paramfile=None, **kwargs):
+        if all([hasattr(self, 'pid_kernels'), PID_offset==self.offset, PID_scale==self.scale, pid_paramfile==self.paramfile]):
+            logging.info('Using existing kernels for PID')
+            return self.pid_kernels
+
+        elif not pid_paramfile in [self.paramfile, None]:
+            logging.info('PID from non-default paramfile %s!'%pid_paramfile)
+            return kernel_from_paramfile(PID_offset, PID_scale, pid_paramfile,
+                                         **kwargs)
+
+        else:
+            logging.info('Using paramfile %s for default PID'%pid_paramfile)
+            logging.info('Scaling PID with %.3f, with offset %.3f'%(PID_scale,
+                                                                    PID_offset))
+            self.pid_kernels = self.kernel_from_paramfile(PID_offset, PID_scale,
+                                                          pid_paramfile,
+                                                          **kwargs)


### PR DESCRIPTION
PID kernels are only calculated over if the values of the systematics are updated. Before, the only way to do this was to pass a boolean flag to get_pid_maps, but then the kernels got recalculated no matter what. The sum of track- and cascade-id probabilities does not become unphysical anymore, since the pid_scale now serves as a relative scaling factor between the two.